### PR TITLE
Fix tennis coach app issue 12

### DIFF
--- a/frontend/src/components/VideoList.css
+++ b/frontend/src/components/VideoList.css
@@ -324,6 +324,63 @@
   font-weight: 600;
 }
 
+/* Analysis Summary */
+.analysis-summary {
+  margin-top: 16px;
+  padding: 12px;
+  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+  border: 1px solid #e0f2fe;
+  border-radius: 8px;
+}
+
+.analysis-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.analysis-icon {
+  font-size: 1rem;
+}
+
+.analysis-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #0369a1;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.analysis-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+
+.stat-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0369a1;
+  line-height: 1;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #64748b;
+  font-weight: 500;
+  text-align: center;
+  margin-top: 2px;
+  line-height: 1.2;
+}
+
 /* Enhanced Actions */
 .video-actions-enhanced {
   padding: 0 20px 20px;

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -228,7 +228,38 @@ const VideoList: React.FC<VideoListProps> = ({ onVideoDeleted, onViewAnalysis })
                         <span className="metadata-value">{video.fps} fps</span>
                       </div>
                     )}
+                    
+                    {video.duration && (
+                      <div className="metadata-row">
+                        <span className="metadata-label">Duration:</span>
+                        <span className="metadata-value">{formatDuration(video.duration)}</span>
+                      </div>
+                    )}
                   </div>
+
+                  {/* Ball Detection Summary */}
+                  {analysis && (
+                    <div className="analysis-summary">
+                      <div className="analysis-header">
+                        <span className="analysis-icon">🎾</span>
+                        <span className="analysis-title">Ball Detection Results</span>
+                      </div>
+                      <div className="analysis-stats">
+                        <div className="stat-item">
+                          <span className="stat-value">{analysis.total_ball_detections}</span>
+                          <span className="stat-label">Total Detections</span>
+                        </div>
+                        <div className="stat-item">
+                          <span className="stat-value">{analysis.frames_with_balls}</span>
+                          <span className="stat-label">Frames with Balls</span>
+                        </div>
+                        <div className="stat-item">
+                          <span className="stat-value">{(analysis.detection_rate * 100).toFixed(1)}%</span>
+                          <span className="stat-label">Detection Rate</span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
                 
                 <div className="video-actions-enhanced">


### PR DESCRIPTION
## Description
This PR addresses issue #12 by enhancing the video analysis display to include ball detection statistics directly on the video cards.

Previously, only basic video metadata (file size, resolution, FPS) was shown. This update adds a new "Ball Detection Results" section that displays:
- **Total Detections**: Number of tennis balls detected.
- **Frames with Balls**: Number of frames containing at least one ball.
- **Detection Rate**: Percentage of frames with successful ball detection.

Styling has also been added to make this section visually distinct and easy to read.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?
- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [x] Manual testing
  - Uploaded a tennis video, ran analysis, and verified that ball detection statistics appeared correctly on the video card.

## Checklist
- [x] I followed the contributing guidelines (CONTRIBUTING.md)
- [x] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [x] No secrets or sensitive data committed

## Screenshots / Videos
Please add screenshots of the updated video cards showing the ball detection results.

## Related issues
Closes #12

---
<a href="https://cursor.com/background-agent?bcId=bc-fdc91fb8-075e-471f-ad9c-391f02274937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fdc91fb8-075e-471f-ad9c-391f02274937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

