### PR TITLE
fix: prevent header injection attacks via filename sanitization

### DIFF
--- a/backend/app/api/routes/video.py
+++ b/backend/app/api/routes/video.py
@@ -135,11 +135,11 @@ async def stream_video(video_id: int, db: Session = Depends(get_db)) -> FileResp
 
         validate_file_exists(file_path, db_video.filename)
 
-        # Return the video file
+        # Return the video file with safe filename to prevent header injection
         return FileResponse(
             path=str(file_path),
             media_type=db_video.content_type or "video/mp4",
-            filename=db_video.filename,
+            filename=get_safe_filename(db_video.filename),
         )
     except (OSError, ValueError) as e:
         log_and_raise_error(e, "stream_video", {"video_id": video_id})
@@ -174,7 +174,7 @@ async def stream_annotated_video(
         return FileResponse(
             path=str(annotated_path),
             media_type="video/mp4",
-            filename=annotated_filename,
+            filename=get_safe_filename(annotated_filename),
         )
     except (OSError, ValueError) as e:
         log_and_raise_error(e, "stream_annotated_video", {"video_id": video_id})

--- a/backend/app/utils/file_validation.py
+++ b/backend/app/utils/file_validation.py
@@ -1,5 +1,9 @@
 """File validation utilities for video uploads."""
 
+import os
+import re
+import secrets
+import unicodedata
 from pathlib import Path
 from typing import Optional
 
@@ -86,24 +90,38 @@ def get_safe_filename(filename: str) -> str:
     """
     Get a safe filename by removing potentially dangerous characters.
 
+    This function prevents header injection attacks by:
+    - Removing all control characters (including CR/LF)
+    - Using only safe ASCII characters
+    - Normalizing Unicode characters
+    - Providing a fallback for empty results
+
     Args:
         filename: Original filename
 
     Returns:
-        Safe filename
+        Safe filename safe for use in HTTP headers
     """
+    # Get just the filename part, removing any path components
+    name = os.path.basename(filename or "")
 
-    # Remove or replace dangerous characters
-    dangerous_chars = ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
-    safe_filename = filename
+    # Normalize Unicode characters
+    name = unicodedata.normalize("NFKC", name)
 
-    for char in dangerous_chars:
-        safe_filename = safe_filename.replace(char, "_")
+    # Remove ALL control characters (0x00-0x1f, 0x7f), including CR/LF
+    name = re.sub(r"[\x00-\x1f\x7f]", "", name)
 
-    # Remove leading/trailing whitespace and dots
-    safe_filename = safe_filename.strip(". ")
+    # Allow only safe ASCII characters: letters, numbers, dots, underscores, hyphens
+    name = re.sub(r"[^A-Za-z0-9._-]", "_", name)
 
-    return safe_filename
+    # Collapse repeated dots and trim leading/trailing dots and spaces
+    name = re.sub(r"\.{2,}", ".", name).strip(" .")
+
+    # If the result is empty or just dots, generate a random name
+    if not name or name == ".":
+        name = f"upload_{secrets.token_hex(8)}"
+
+    return name
 
 
 def ensure_unique_filename(filename: str, directory: Path) -> str:

--- a/backend/tests/test_file_validation.py
+++ b/backend/tests/test_file_validation.py
@@ -1,0 +1,128 @@
+"""Tests for file validation utilities."""
+
+from app.utils.file_validation import get_safe_filename
+
+
+class TestFileValidation:
+    """Test file validation utilities."""
+
+    def test_get_safe_filename_normal_filenames(self) -> None:
+        """Test that normal filenames are preserved."""
+        test_cases = [
+            ("video.mp4", "video.mp4"),
+            ("my_video.mp4", "my_video.mp4"),
+            ("tennis-match.mp4", "tennis-match.mp4"),
+            ("video_123.mp4", "video_123.mp4"),
+        ]
+
+        for original, expected in test_cases:
+            result = get_safe_filename(original)
+            assert result == expected, (
+                f"Expected {expected}, got {result} for {original}"
+            )
+
+    def test_get_safe_filename_removes_dangerous_chars(self) -> None:
+        """Test that dangerous characters are removed or replaced."""
+        test_cases = [
+            ("file with spaces.mp4", "file_with_spaces.mp4"),
+            (
+                "file!@#$%^&*().mp4",
+                "file__________.mp4",
+            ),  # Each special char becomes underscore
+            ("file[].mp4", "file__.mp4"),
+            ("file{}.mp4", "file__.mp4"),
+            ("file().mp4", "file__.mp4"),
+        ]
+
+        for original, expected in test_cases:
+            result = get_safe_filename(original)
+            assert result == expected, (
+                f"Expected {expected}, got {result} for {original}"
+            )
+
+    def test_get_safe_filename_removes_control_chars(self) -> None:
+        """Test that control characters are removed."""
+        # Test CR/LF injection attempt
+        malicious_filename = "innocent.mp4\r\nSet-Cookie: session=stolen\r\n\r\n"
+        result = get_safe_filename(malicious_filename)
+
+        # Should remove control characters but keep the text (replacing unsafe chars with underscores)
+        assert "\r" not in result
+        assert "\n" not in result
+        assert result == "innocent.mp4Set-Cookie__session_stolen"
+
+    def test_get_safe_filename_removes_path_traversal(self) -> None:
+        """Test that path traversal attempts are neutralized."""
+        test_cases = [
+            ("../../../etc/passwd", "passwd"),  # Only the filename part remains
+            (
+                "..\\..\\..\\windows\\system32\\config",
+                "_._._windows_system32_config",
+            ),  # Backslashes become underscores
+            ("/etc/passwd", "passwd"),  # Only the filename part remains
+            (
+                "C:\\Windows\\System32\\config",
+                "C__Windows_System32_config",
+            ),  # Backslashes become underscores
+        ]
+
+        for original, expected in test_cases:
+            result = get_safe_filename(original)
+            assert result == expected, (
+                f"Expected {expected}, got {result} for {original}"
+            )
+
+    def test_get_safe_filename_handles_unicode(self) -> None:
+        """Test that Unicode characters are normalized."""
+        test_cases = [
+            ("vidéo.mp4", "vid_o.mp4"),  # Unicode chars become underscores
+            ("file\u0000name.mp4", "filename.mp4"),  # Null byte removed
+            ("file\u0001name.mp4", "filename.mp4"),  # Control char removed
+        ]
+
+        for original, expected in test_cases:
+            result = get_safe_filename(original)
+            assert result == expected, (
+                f"Expected {expected}, got {result} for {original}"
+            )
+
+    def test_get_safe_filename_handles_empty_and_dots(self) -> None:
+        """Test that empty filenames and dot-only filenames get fallback names."""
+        # Empty filename should get random fallback
+        result = get_safe_filename("")
+        assert result.startswith("upload_")
+        assert len(result) == 23  # "upload_" + 16 hex chars
+
+        # Dot-only filename should get random fallback
+        result = get_safe_filename(".")
+        assert result.startswith("upload_")
+        assert len(result) == 23
+
+        # Multiple dots should be collapsed
+        result = get_safe_filename("file..name.mp4")
+        assert result == "file.name.mp4"
+
+    def test_get_safe_filename_removes_leading_trailing_dots(self) -> None:
+        """Test that leading and trailing dots are removed."""
+        test_cases = [
+            (".file.mp4", "file.mp4"),
+            ("file.mp4.", "file.mp4"),
+            ("..file.mp4..", "file.mp4"),
+            ("   file.mp4   ", "___file.mp4___"),  # Spaces become underscores
+        ]
+
+        for original, expected in test_cases:
+            result = get_safe_filename(original)
+            assert result == expected, (
+                f"Expected {expected}, got {result} for {original}"
+            )
+
+    def test_get_safe_filename_url_encoded_attack(self) -> None:
+        """Test that URL-encoded attack attempts are neutralized."""
+        # URL-encoded CR/LF
+        malicious_filename = "file%0d%0aSet-Cookie:%20evil=value%0d%0a%0d%0a.mp4"
+        result = get_safe_filename(malicious_filename)
+
+        # Should remove the encoded control characters but keep the text
+        assert "%" not in result
+        assert result == "file_0d_0aSet-Cookie__20evil_value_0d_0a_0d_0a.mp4"


### PR DESCRIPTION
- Implement strict filename sanitization in get_safe_filename()
- Remove all control characters (CR/LF) that could cause header injection
- Use whitelist approach for safe ASCII characters only
- Apply safe filename in FileResponse headers for video streaming
- Add comprehensive tests for filename sanitization
- Fixes GitHub code scanning alert #24

## Description
Describe what this PR does and why.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?
- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [ ] Manual testing

## Checklist
- [ ] I followed the contributing guidelines (CONTRIBUTING.md)
- [ ] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [ ] No secrets or sensitive data committed

## Screenshots / Videos
If UI changes, add screenshots or a short video.

## Related issues
Link issues (e.g., Closes #123).
