### PR TITLE
fix: resolve video deletion cascade bug and improve code organization

### DIFF
--- a/backend/app/api/routes/video.py
+++ b/backend/app/api/routes/video.py
@@ -22,11 +22,10 @@ from app.api.schemas.video import (
 )
 from app.core.config import settings
 from app.core.database import get_db
-from app.models.analysis import Analysis
 from app.services.quality_service import quick_assess_video_quality
 from app.services.video_service import (
     create_video_record,
-    delete_video_record,
+    delete_video_with_analyses,
     get_all_videos,
     get_video_by_id,
     update_video_quality,
@@ -202,49 +201,18 @@ async def delete_video(
         Deletion confirmation
     """
     try:
-        # Get video from database
-        db_video = get_video_by_id(db, video_id)
-        if not db_video:
-            raise handle_not_found_error("video", str(video_id))
+        # Use service function to handle all deletion logic
+        success, filename, deleted_video_id = delete_video_with_analyses(db, video_id)
 
-        # Delete associated analysis files first (before cascade deletion)
-        analyses = db.query(Analysis).filter(Analysis.video_id == video_id).all()
-        for analysis in analyses:
-            # Delete annotated video files
-            if analysis.annotated_video_path:
-                annotated_path = Path(analysis.annotated_video_path)
-                if annotated_path.exists():
-                    try:
-                        annotated_path.unlink()
-                        logger.info(f"Deleted annotated video: {annotated_path}")
-                    except OSError as e:
-                        logger.warning(
-                            f"Failed to delete annotated video {annotated_path}: {e}"
-                        )
-
-        # Delete original video file from file system
-        upload_dir = Path(settings.UPLOAD_DIR)
-        file_path = upload_dir / db_video.filename
-
-        if file_path.exists() and file_path.is_file():
-            try:
-                file_path.unlink()
-                logger.info(f"Deleted original video: {file_path}")
-            except OSError as e:
-                raise handle_file_error(
-                    "delete_failed", db_video.filename, str(e)
-                ) from e
-
-        # Delete from database (this will cascade delete analyses)
-        if not delete_video_record(db, db_video.filename):
+        if not success:
             raise handle_file_error(
-                "delete_failed", db_video.filename, "Database deletion failed"
+                "delete_failed", filename or "unknown", "Video deletion failed"
             )
 
         return VideoDeleteResponse(
-            message=f"Video {db_video.filename} deleted successfully",
-            video_id=video_id,
-            filename=db_video.filename,
+            message=f"Video {filename} deleted successfully",
+            video_id=deleted_video_id,
+            filename=filename,
         )
     except (OSError, ValueError) as e:
         log_and_raise_error(e, "delete_video", {"video_id": video_id})

--- a/backend/app/services/video_service.py
+++ b/backend/app/services/video_service.py
@@ -1,8 +1,11 @@
+import logging
 from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
 from app.models.video import Video
+
+logger = logging.getLogger(__name__)
 
 
 def create_video_record(
@@ -51,14 +54,87 @@ def get_all_videos(db: Session) -> List[Video]:
     return db.query(Video).order_by(Video.created_at.desc()).all()
 
 
-def delete_video_record(db: Session, filename: str) -> bool:
-    """Delete video record from database."""
+def delete_video_record(db: Session, video_id: int) -> bool:
+    """Delete video record from database by ID."""
+    video = db.query(Video).filter(Video.id == video_id).first()
+    if video:
+        db.delete(video)
+        db.commit()
+        return True
+    return False
+
+
+def delete_video_by_filename(db: Session, filename: str) -> bool:
+    """Delete video record from database by filename."""
     video = db.query(Video).filter(Video.filename == filename).first()
     if video:
         db.delete(video)
         db.commit()
         return True
     return False
+
+
+def delete_video_with_analyses(db: Session, video_id: int) -> tuple[bool, str, int]:
+    """
+    Delete a video and all its associated analyses, including file cleanup.
+
+    Args:
+        db: Database session
+        video_id: ID of the video to delete
+
+    Returns:
+        Tuple of (success: bool, filename: str, video_id: int)
+    """
+    from pathlib import Path
+
+    from app.core.config import settings
+    from app.models.analysis import Analysis
+
+    # Get video from database
+    video = get_video_by_id(db, video_id)
+    if not video:
+        return False, "", video_id
+
+    filename = video.filename
+
+    try:
+        # Delete associated analysis files first (before cascade deletion)
+        analyses = db.query(Analysis).filter(Analysis.video_id == video_id).all()
+        for analysis in analyses:
+            # Delete annotated video files
+            if analysis.annotated_video_path:
+                annotated_path = Path(analysis.annotated_video_path)
+                if annotated_path.exists():
+                    try:
+                        annotated_path.unlink()
+                        logger.info(f"Deleted annotated video: {annotated_path}")
+                    except OSError as e:
+                        logger.warning(
+                            f"Failed to delete annotated video {annotated_path}: {e}"
+                        )
+
+        # Delete original video file from file system
+        upload_dir = Path(settings.UPLOAD_DIR)
+        file_path = upload_dir / filename
+
+        if file_path.exists() and file_path.is_file():
+            try:
+                file_path.unlink()
+                logger.info(f"Deleted original video: {file_path}")
+            except OSError as e:
+                logger.error(f"Failed to delete video file {file_path}: {e}")
+                # Continue with database deletion even if file deletion fails
+
+        # Delete from database (this will cascade delete analyses)
+        if not delete_video_record(db, video_id):
+            logger.error(f"Database deletion failed for video {video_id}")
+            return False, filename, video_id
+
+        return True, filename, video_id
+
+    except (OSError, ValueError, RuntimeError) as e:
+        logger.error(f"Error during video deletion for {video_id}: {e}")
+        return False, filename, video_id
 
 
 def update_video_status(

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -153,6 +153,81 @@ class TestVideoIntegration:
             if os.path.exists(tmp_file_path):
                 os.unlink(tmp_file_path)
 
+    def test_video_deletion_cascade_behavior(self, client: TestClient) -> None:
+        """Test that video deletion correctly cascades to analyses without affecting other videos."""
+        # Use the real test video file
+        test_video_path = Path(__file__).parent / "test_data" / "test_tennis_video.mp4"
+        if not test_video_path.exists():
+            pytest.skip("Test video file not found")
+
+        # Upload first video
+        with open(test_video_path, "rb") as f:
+            files = {"file": ("test_video_1.mp4", f, "video/mp4")}
+            response = client.post("/v0/videos/upload", files=files)
+
+        assert response.status_code == 200
+        video_1_id = response.json()["video_id"]
+
+        # Upload second video
+        with open(test_video_path, "rb") as f:
+            files = {"file": ("test_video_2.mp4", f, "video/mp4")}
+            response = client.post("/v0/videos/upload", files=files)
+
+        assert response.status_code == 200
+        video_2_id = response.json()["video_id"]
+
+        # Create analysis for first video
+        analysis_request = {
+            "analysis_type": "ball_tracking",
+            "confidence_threshold": 0.5,
+            "include_pose_detection": False,
+            "synchronous": True,
+        }
+
+        response = client.post(
+            f"/v0/analysis/videos/{video_1_id}", json=analysis_request
+        )
+        assert response.status_code == 200
+        analysis_1_data = response.json()
+        analysis_1_id = analysis_1_data["analysis_id"]
+
+        # Create analysis for second video
+        response = client.post(
+            f"/v0/analysis/videos/{video_2_id}", json=analysis_request
+        )
+        assert response.status_code == 200
+        analysis_2_data = response.json()
+        analysis_2_id = analysis_2_data["analysis_id"]
+
+        # Verify both analyses exist
+        response = client.get(f"/v0/analysis/{analysis_1_id}")
+        assert response.status_code == 200
+
+        response = client.get(f"/v0/analysis/{analysis_2_id}")
+        assert response.status_code == 200
+
+        # Delete first video
+        response = client.delete(f"/v0/videos/{video_1_id}")
+        assert response.status_code == 200
+
+        # Verify first video and its analysis are deleted
+        response = client.get(f"/v0/videos/{video_1_id}")
+        assert response.status_code == 404
+
+        response = client.get(f"/v0/analysis/{analysis_1_id}")
+        assert response.status_code == 404
+
+        # Verify second video and its analysis still exist
+        response = client.get(f"/v0/videos/{video_2_id}")
+        assert response.status_code == 200
+
+        response = client.get(f"/v0/analysis/{analysis_2_id}")
+        assert response.status_code == 200
+
+        # Clean up second video
+        response = client.delete(f"/v0/videos/{video_2_id}")
+        assert response.status_code == 200
+
 
 class TestAnalysisIntegration:
     """Integration tests for analysis endpoints."""


### PR DESCRIPTION
- Fix critical bug where delete_video_record used filename instead of video_id
- Move complex deletion logic from API layer to service layer
- Add delete_video_with_analyses() service function for proper separation of concerns
- Add comprehensive test to verify cascade deletion behavior
- Ensure video deletion only affects target video, not other videos' analyses
- Follow Python code standards and API patterns
- Add proper error handling and logging

## Description
Describe what this PR does and why.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?
- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [ ] Manual testing

## Checklist
- [ ] I followed the contributing guidelines (CONTRIBUTING.md)
- [ ] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [ ] No secrets or sensitive data committed

## Screenshots / Videos
If UI changes, add screenshots or a short video.

## Related issues
Link issues (e.g., Closes #123).
