### PR TITLE
Revert: CORS commit that was pushed directly to main

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -78,11 +78,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Tennis Coach API"
 
     # CORS
-    BACKEND_CORS_ORIGINS: list[str] = [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "https://aseda-sam.github.io",
-    ]
+    BACKEND_CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]
 
     @property
     def database_url(self) -> str:


### PR DESCRIPTION
Reverting the CORS commit that was accidentally pushed directly to main. The proper fix will come via PR from fix/cors-github-pages-origin branch.