### PR TITLE
Fix CORS: Add GitHub Pages origin to allowed origins

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -78,7 +78,11 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Tennis Coach API"
 
     # CORS
-    BACKEND_CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]
+    BACKEND_CORS_ORIGINS: list[str] = [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://aseda-sam.github.io",
+    ]
 
     @property
     def database_url(self) -> str:


### PR DESCRIPTION
## Description
Fixes CORS error when frontend deployed on GitHub Pages tries to connect to the backend API on Render.

## Changes
- Added `https://aseda-sam.github.io` to `BACKEND_CORS_ORIGINS` in backend config
- Allows API requests from the deployed GitHub Pages frontend

## Type of change
- [x] Bug fix

## How has this been tested?
- [x] Verified CORS configuration allows GitHub Pages origin
- [ ] Manual testing after deployment (requires backend redeploy on Render)

## Checklist
- [x] I followed the contributing guidelines (CONTRIBUTING.md)
- [x] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [x] No secrets or sensitive data committed

## Related issues
Fixes CORS blocking issue when uploading videos from GitHub Pages frontend.