### PR TITLE
Fix production API URL: change from /api to /v0 prefix

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,10 +2,10 @@ name: Deploy Frontend
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'frontend/**'
-      - '.github/workflows/deploy-frontend.yml'
+      - "frontend/**"
+      - ".github/workflows/deploy-frontend.yml"
 
 permissions:
   pages: write
@@ -24,22 +24,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'frontend/package-lock.json'
-          
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Build
         run: npm run build
         env:
-          REACT_APP_API_URL: https://tennis-coach-backend.onrender.com/api
-        
+          REACT_APP_API_URL: https://tennis-coach-backend.onrender.com/v0
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Description
Fixes the production deployment configuration to use the correct API prefix `/v0` instead of the outdated `/api` prefix. The GitHub Pages frontend was making requests to `https://tennis-coach-backend.onrender.com/api/videos/` but the backend API routes are mounted at `/v0/videos/`, causing connection failures in production.

This change updates the `REACT_APP_API_URL` environment variable in the GitHub Actions deployment workflow to point to the correct API version endpoint.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?
- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [x] Manual testing

Verified that:
- Backend routes are correctly mounted at `/v0/videos`, `/v0/ball-contacts`, etc. in `backend/app/main.py`
- Frontend code already defaults to `/v0` for local development in `frontend/src/services/api.ts`
- Production build will now use the correct API base URL

## Checklist
- [x] I followed the contributing guidelines (CONTRIBUTING.md)
- [x] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [x] No secrets or sensitive data committed

## Screenshots / Videos
N/A - Configuration change only

## Related issues
Fixes production deployment issue where frontend cannot connect to backend API endpoints.