### PR TITLE
feat(frontend): add coach note and status pill to serve attempts

### DIFF
--- a/frontend/src/components/AnalysisRightPanel.css
+++ b/frontend/src/components/AnalysisRightPanel.css
@@ -400,6 +400,14 @@
   gap: var(--spacing-sm);
   padding-top: var(--spacing-xs);
   border-top: 1px solid var(--color-border-light);
+  flex-wrap: wrap;
+}
+
+.analysis-right-panel__metric-angle-main {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+  flex: 1;
 }
 
 .analysis-right-panel__angle-value {
@@ -411,6 +419,42 @@
 .analysis-right-panel__angle-label {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
+}
+
+/* Feedback Pill */
+.analysis-right-panel__feedback-pill {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.analysis-right-panel__feedback-pill--great {
+  background: var(--color-success-light);
+  color: var(--color-success-dark);
+}
+
+.analysis-right-panel__feedback-pill--solid {
+  background: var(--color-info-light);
+  color: var(--color-info-dark);
+}
+
+.analysis-right-panel__feedback-pill--focus {
+  background: var(--color-warning-light);
+  color: var(--color-warning-dark);
+}
+
+/* Coach Note */
+.analysis-right-panel__coach-note {
+  margin-top: var(--spacing-sm);
+  padding-top: var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+  font-style: italic;
 }
 
 .analysis-right-panel__angle-desc {

--- a/frontend/src/components/ServeAttemptsPanel.tsx
+++ b/frontend/src/components/ServeAttemptsPanel.tsx
@@ -9,6 +9,38 @@ interface ServeAttemptsPanelProps {
   isDemo?: boolean;
 }
 
+interface ElbowAngleFeedback {
+  level: 'great' | 'solid' | 'focus';
+  pillText: string;
+  coachNote: string;
+}
+
+/**
+ * Maps elbow angle (in degrees) to feedback level, pill text, and coach note.
+ * Frontend-only heuristic for MVP - will be replaced with LLM-based recommendations.
+ */
+const getElbowAngleFeedback = (angleDeg: number): ElbowAngleFeedback => {
+  if (angleDeg >= 170) {
+    return {
+      level: 'great',
+      pillText: 'Great',
+      coachNote: 'Nice extension at contact—keep that relaxed arm through the finish.',
+    };
+  } else if (angleDeg >= 160) {
+    return {
+      level: 'solid',
+      pillText: 'Solid',
+      coachNote: 'Good extension—try reaching a touch more at contact for extra power.',
+    };
+  } else {
+    return {
+      level: 'focus',
+      pillText: 'Focus',
+      coachNote: 'Work on extending through contact—think "reach up and out" as you hit.',
+    };
+  }
+};
+
 const ServeAttemptsPanel: React.FC<ServeAttemptsPanelProps> = ({
   videoId,
   onServeAttemptClick,
@@ -97,14 +129,33 @@ const ServeAttemptsPanel: React.FC<ServeAttemptsPanelProps> = ({
                     </div>
                   </div>
                   {hasMetrics ? (
-                    <div className="analysis-right-panel__metric-angle">
-                      <span className="analysis-right-panel__angle-value">
-                        {Math.round(serveAttempt.elbow_angle_at_contact as number)}°
-                      </span>
-                      <span className="analysis-right-panel__angle-label">
-                        Elbow Angle
-                      </span>
-                    </div>
+                    (() => {
+                      const feedback = getElbowAngleFeedback(
+                        serveAttempt.elbow_angle_at_contact as number
+                      );
+                      return (
+                        <>
+                          <div className="analysis-right-panel__metric-angle">
+                            <div className="analysis-right-panel__metric-angle-main">
+                              <span className="analysis-right-panel__angle-value">
+                                {Math.round(serveAttempt.elbow_angle_at_contact as number)}°
+                              </span>
+                              <span className="analysis-right-panel__angle-label">
+                                Elbow Angle
+                              </span>
+                            </div>
+                            <span
+                              className={`analysis-right-panel__feedback-pill analysis-right-panel__feedback-pill--${feedback.level}`}
+                            >
+                              {feedback.pillText}
+                            </span>
+                          </div>
+                          <div className="analysis-right-panel__coach-note">
+                            {feedback.coachNote}
+                          </div>
+                        </>
+                      );
+                    })()
                   ) : (
                     <div className="analysis-right-panel__metric-angle">
                       <span className="analysis-right-panel__angle-label">


### PR DESCRIPTION
- Add elbow angle feedback mapping (Great/Solid/Focus thresholds)
- Display status pill with semantic colors next to angle value
- Show one actionable coach note per serve attempt with metrics
- Use existing design tokens for consistent styling
- Frontend-only MVP implementation (will be replaced with LLM recommendations)

## Description
Describe what this PR does and why.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?
- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [ ] Manual testing

## Checklist
- [ ] I followed the contributing guidelines (CONTRIBUTING.md)
- [ ] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [ ] No secrets or sensitive data committed

## Screenshots / Videos
If UI changes, add screenshots or a short video.

## Related issues
Link issues (e.g., Closes #123).
