### PR TITLE
fix: handle Redis quota exceeded error during startup

### DIFF
--- a/backend/app/core/redis_config.py
+++ b/backend/app/core/redis_config.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, urlunparse
 
 from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError as RedisResponseError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from rq import Queue
 
@@ -65,6 +66,13 @@ except (RedisConnectionError, RedisTimeoutError, OSError) as e:
         "Some features (background tasks) will not work until Redis is available."
     )
     # Don't raise - allow module to load for testing
+except RedisResponseError as e:
+    # Catch Redis response errors (e.g., quota exceeded on Upstash free tier)
+    logger.warning(
+        f"Redis error at {_mask_redis_url(REDIS_URL)}: {e}. "
+        "Some features (background tasks) may not work."
+    )
+    # Don't raise - allow module to load
 
 # Create default queue
 default_queue = Queue("default", connection=redis_conn)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,6 +74,7 @@ def start_rq_worker() -> Optional[subprocess.Popen]:
     """
     try:
         from redis.exceptions import ConnectionError as RedisConnectionError
+        from redis.exceptions import ResponseError as RedisResponseError
         from redis.exceptions import TimeoutError as RedisTimeoutError
         from rq import Worker
 
@@ -91,10 +92,15 @@ def start_rq_worker() -> Optional[subprocess.Popen]:
             return None
         else:
             logger.info("No existing workers found in Redis")
-    except (RedisConnectionError, RedisTimeoutError, AttributeError) as e:
+    except (
+        RedisConnectionError,
+        RedisTimeoutError,
+        RedisResponseError,
+        AttributeError,
+    ) as e:
         logger.warning(
             f"Could not check for existing workers: {e}. "
-            "This might mean Redis is not available or connection failed. "
+            "This might mean Redis is unavailable, quota exceeded, or connection failed. "
             "Worker startup will be skipped to avoid duplicates."
         )
         # Don't start worker if we can't check - safer to skip than risk duplicates


### PR DESCRIPTION
The Upstash Redis free tier has a 500k requests/month limit. When
exceeded, Worker.all() throws ResponseError which wasn't caught,
crashing the API on startup.

- Add ResponseError to exception handling in start_rq_worker()
- Add catch-all for Redis errors during initial ping in redis_config
- API now starts gracefully when Redis quota is exceeded (background
  tasks disabled, but API serves requests)

## Description

Describe what this PR does and why. Include key design decisions and alternatives considered.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## How has this been tested?

- [ ] Backend tests (pytest)
- [ ] Frontend tests (npm test)
- [ ] Manual testing

## Checklist

- [ ] I followed the contributing guidelines (CONTRIBUTING.md)
- [ ] I ran code quality checks (ruff / eslint)
- [ ] I updated documentation (if needed)
- [ ] No secrets or sensitive data committed

## Screenshots / Videos

If UI changes, add screenshots or a short video.

## Related Issues

Closes #
