### PR TITLE
Add docs/private/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ venv.bak/
 
 # .agents/ — shared cross-tool skills (tracked)
 
+# Private docs (GTM, strategy, business — local-only)
+docs/private/
+
 # Claude AI (local-only)
 .claude/
 CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `docs/private/` to `.gitignore` for local-only business/strategy docs

## Test plan
- [x] Verify `docs/private/` contents are not tracked by git