### PR TITLE
Identify account owner's player via is_self flag, not creation order

### DIFF
--- a/backend/alembic/versions/b7e4d1a9c3f2_add_is_self_to_players.py
+++ b/backend/alembic/versions/b7e4d1a9c3f2_add_is_self_to_players.py
@@ -1,0 +1,54 @@
+"""add is_self flag to players
+
+The account owner's player is now identified by an explicit is_self flag
+instead of creation order. Backfill: for each user, the earliest-created
+player that is not the dedicated "Someone Else" player is marked as self.
+This matches the previous implicit behaviour (first-created player was
+treated as the owner) except that "Someone Else" can no longer be adopted
+as the owner's identity.
+
+Revision ID: b7e4d1a9c3f2
+Revises: a9f3c2e1b4d8
+Create Date: 2026-07-05
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e4d1a9c3f2"
+down_revision: Union[str, Sequence[str], None] = "a9f3c2e1b4d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "players",
+        sa.Column(
+            "is_self", sa.Boolean(), server_default=sa.text("false"), nullable=False
+        ),
+    )
+    # Backfill: earliest non-"Someone Else" player per user becomes self.
+    op.execute(
+        """
+        UPDATE players
+        SET is_self = true
+        WHERE id IN (
+            SELECT DISTINCT ON (user_id) id
+            FROM players
+            WHERE name != 'Someone Else'
+            ORDER BY user_id, created_at ASC
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("players", "is_self")

--- a/backend/app/api/schemas/player.py
+++ b/backend/app/api/schemas/player.py
@@ -65,6 +65,10 @@ class PlayerInfo(BaseModel):
     age_group: Optional[AgeGroup] = Field(description="Player age group")
     gender: Optional[Gender] = Field(description="Player gender identity")
     notes: Optional[str] = Field(description="Additional notes")
+    is_self: bool = Field(
+        default=False,
+        description="True when this player represents the account owner",
+    )
     created_at: datetime = Field(description="Creation timestamp")
     updated_at: Optional[datetime] = Field(description="Last update timestamp")
 

--- a/backend/app/models/player.py
+++ b/backend/app/models/player.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Float, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -43,6 +43,11 @@ class Player(Base):
 
     # Authentication - user who owns this player
     user_id: Mapped[str] = mapped_column(String(36), index=True)  # UUID as string
+
+    # True for the player representing the account owner themselves.
+    # Exactly one player per user should have this set; identity must come
+    # from this flag, never from creation order.
+    is_self: Mapped[bool] = mapped_column(Boolean, server_default=text("false"))
 
     # Relationships
     serve_windows: Mapped[list["ServeWindow"]] = relationship(  # type: ignore[name-defined]

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -337,14 +337,34 @@ def get_or_create_default_player(
     Returns:
         Player: The default player for this user
     """
-    # Check for existing default player (look for any player owned by this user)
-    # In practice, users should only have one default player, but we check by user_id
+    # The owner's player is identified by the is_self flag, never by
+    # creation order (a "someone else" player may predate the owner's own).
     default_player = (
         db.query(Player)
-        .filter(Player.user_id == user_id)
-        .order_by(Player.created_at.asc())  # Get the first created player
+        .filter(Player.user_id == user_id, Player.is_self.is_(True))
         .first()
     )
+
+    if default_player is None:
+        # Legacy data: players exist but none is flagged. Adopt the earliest
+        # (matching the old creation-order behaviour) and persist the flag.
+        legacy_player = (
+            db.query(Player)
+            .filter(Player.user_id == user_id, Player.name != OTHER_PLAYER_NAME)
+            .order_by(Player.created_at.asc())
+            .first()
+        )
+        if legacy_player:
+            logger.info(
+                "Adopting earliest player as self for user %s: ID=%s, name='%s'",
+                user_id,
+                legacy_player.id,
+                legacy_player.name,
+            )
+            legacy_player.is_self = True
+            db.commit()
+            db.refresh(legacy_player)
+            default_player = legacy_player
 
     if default_player:
         logger.debug(
@@ -395,6 +415,7 @@ def get_or_create_default_player(
         age_group=age_group,
         gender=gender,
         user_id=user_id,
+        is_self=True,
     )
     db.add(default_player)
     db.commit()

--- a/backend/docs/database_schema.md
+++ b/backend/docs/database_schema.md
@@ -33,6 +33,10 @@ Stores player profiles (one default per user, with optional additional players).
 - `name` (required)
 - `dominant_hand` (required)
 - `backhand_style`, `height_cm`, `age_group`, `gender`, `notes`
+- `is_self` (bool, default false) — true for the player representing the account
+  owner. Exactly one per user; identity derives from this flag, never from
+  creation order. Backfilled in migration `b7e4d1a9c3f2` (earliest non-"Someone
+  Else" player per user).
 
 ## ball_detections
 

--- a/backend/tests/test_player_identity.py
+++ b/backend/tests/test_player_identity.py
@@ -1,0 +1,95 @@
+"""
+Tests for player self-identity (is_self flag).
+
+Contract: the account owner's player is identified by an explicit is_self
+flag, not by creation order. Creation order is an accident (a user may tag
+a "someone else" player before their own profile exists) and must not
+determine who "you" are.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.player import Player
+from app.services import player_service
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_player(db, name: str, created_offset_min: int = 0, **kwargs) -> Player:
+    player = Player(
+        name=name,
+        dominant_hand="right",
+        user_id=TEST_USER_ID,
+        created_at=datetime.now(timezone.utc) + timedelta(minutes=created_offset_min),
+        **kwargs,
+    )
+    db.add(player)
+    db.commit()
+    db.refresh(player)
+    return player
+
+
+class TestDefaultPlayerIdentity:
+    def test_created_default_player_is_flagged_as_self(self, db_session):
+        player = player_service.get_or_create_default_player(db_session, TEST_USER_ID)
+
+        assert player.is_self is True
+
+    def test_returns_self_player_even_when_older_player_exists(self, db_session):
+        # An opponent/"someone else" player created BEFORE the owner's profile
+        _make_player(db_session, "Perricard", created_offset_min=0, is_self=False)
+        me = _make_player(db_session, "Aseda", created_offset_min=5, is_self=True)
+
+        result = player_service.get_or_create_default_player(db_session, TEST_USER_ID)
+
+        assert result.id == me.id
+        assert result.name == "Aseda"
+
+    def test_self_heals_when_no_player_is_flagged(self, db_session):
+        # Legacy data: players exist but none is flagged (pre-migration state).
+        # The earliest-created player is adopted as self, matching the old
+        # creation-order behaviour, and the flag is persisted.
+        first = _make_player(db_session, "Me", created_offset_min=0, is_self=False)
+        _make_player(db_session, "Opponent", created_offset_min=5, is_self=False)
+
+        result = player_service.get_or_create_default_player(db_session, TEST_USER_ID)
+
+        assert result.id == first.id
+        assert result.is_self is True
+        db_session.refresh(first)
+        assert first.is_self is True
+
+    def test_self_heal_never_adopts_someone_else_player(self, db_session):
+        # The dedicated "Someone Else" player must never become "you",
+        # even when it is the earliest-created player.
+        _make_player(db_session, "Someone Else", created_offset_min=0, is_self=False)
+        me = _make_player(db_session, "Me", created_offset_min=5, is_self=False)
+
+        result = player_service.get_or_create_default_player(db_session, TEST_USER_ID)
+
+        assert result.id == me.id
+        assert result.is_self is True
+
+    def test_does_not_adopt_another_users_player(self, db_session):
+        other = Player(
+            name="Other user's player",
+            dominant_hand="right",
+            user_id="11111111-1111-1111-1111-111111111111",
+            is_self=True,
+        )
+        db_session.add(other)
+        db_session.commit()
+
+        result = player_service.get_or_create_default_player(db_session, TEST_USER_ID)
+
+        assert result.id != other.id
+        assert result.user_id == TEST_USER_ID
+
+
+class TestMeEndpointContract:
+    def test_me_endpoint_reports_is_self(self, client):
+        response = client.get("/v0/players/me")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_self"] is True

--- a/frontend/src/components/VideoList.test.tsx
+++ b/frontend/src/components/VideoList.test.tsx
@@ -262,12 +262,26 @@ describe('VideoList', () => {
       expect(screen.getByText('2 sessions')).toBeInTheDocument();
     });
 
-    it('shows "You" badge when primary_player_id matches', () => {
+    it('shows "You" badge only when primary_player_id matches the profile', () => {
       renderWithProviders(<VideoList />);
 
-      // Both videos resolve to "You": video 1 matches by id, video 2 has null primary_player_id
+      // Only video 1 matches by id; video 2 is untagged and gets no badge
       const labels = screen.getAllByText('You');
-      expect(labels.length).toBeGreaterThan(0);
+      expect(labels).toHaveLength(1);
+    });
+
+    it('shows no player badge for untagged videos', () => {
+      // Untagged (primary_player_id null/undefined) means "we don't know",
+      // not "you" — no badge should render.
+      const untaggedOnly: VideoMetadata[] = [
+        { ...mockVideos[1], primary_player_id: null },
+      ];
+      setDefaultMocks({ videos: untaggedOnly });
+
+      renderWithProviders(<VideoList />);
+
+      expect(screen.queryByText('You')).not.toBeInTheDocument();
+      expect(screen.queryByText('Someone Else')).not.toBeInTheDocument();
     });
 
     it('shows no player badge when player profile is not available', () => {

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -111,10 +111,9 @@ const VideoList: React.FC<VideoListProps> = ({
     (video: VideoMetadata): 'you' | 'someone_else' | null => {
       if (profileLoading) return null;
       if (!playerProfile?.id) return null;
-      if (
-        !video.primary_player_id ||
-        video.primary_player_id === playerProfile.id
-      ) {
+      // Untagged videos get no badge — absence of a tag is not identity.
+      if (!video.primary_player_id) return null;
+      if (video.primary_player_id === playerProfile.id) {
         return 'you';
       }
       return 'someone_else';

--- a/frontend/src/types/player.ts
+++ b/frontend/src/types/player.ts
@@ -19,6 +19,8 @@ export interface PlayerInfo {
   age_group?: string | null;
   gender?: string | null;
   notes?: string | null;
+  /** True when this player represents the account owner. */
+  is_self?: boolean;
   created_at: string;
   updated_at?: string | null;
 }


### PR DESCRIPTION
## Summary

Fixes the "Me" vs player identity bug (backlog: high severity). The account owner's player was resolved as *the earliest-created player for the user* — so an opponent or "Someone Else" player created first would permanently become "you" across filters, badges, and the account menu. Untagged videos also displayed a confident "You" badge.

- Add explicit `is_self` flag to `Player`; `get_or_create_default_player` now looks up by flag, never creation order
- Legacy rows self-heal: earliest non-"Someone Else" player is adopted and flagged
- Migration `b7e4d1a9c3f2` backfills earliest non-"Someone Else" player per user (verified against local data: "Me" flagged, "Someone Else" not)
- `PlayerInfo` exposes `is_self` (backend schema + frontend type)
- `VideoList` no longer shows a "You" badge on untagged videos — absence of a tag is not identity

## Test plan

- TDD: 6 new tests in `backend/tests/test_player_identity.py` (flag on create, flag beats creation order, self-heal, Someone Else never adopted, cross-user isolation, `/players/me` contract) — all written red first
- 2 new/updated Vitest cases for the untagged-badge behaviour in `VideoList.test.tsx`
- Full backend suite: 491 passed; pyright clean; frontend tsc clean
- Note: `AuthForm.test.tsx` fails pre-existing on main (localStorage missing in test env, invisible to CI) — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)