### PR TITLE
Polyfill Web Storage in vitest setup for Node 25+

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -11,3 +11,46 @@ import '@testing-library/jest-dom';
     unobserve() {}
     disconnect() {}
   };
+
+// Node 25+ ships its own Web Storage API, which collides with jsdom's and
+// leaves window.localStorage undefined under vitest
+// (https://github.com/vitest-dev/vitest/issues/8757). Provide an in-memory
+// Storage when the environment didn't. No-op on Node versions where jsdom's
+// own storage works (e.g. Node 20 in CI).
+class MemoryStorage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  if (typeof globalThis[name]?.clear !== 'function') {
+    Object.defineProperty(globalThis, name, {
+      value: new MemoryStorage(),
+      configurable: true,
+      writable: true,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Node 25+ enables its own Web Storage API by default, which collides with jsdom's and leaves `window.localStorage` undefined under vitest ([vitest-dev/vitest#8757](https://github.com/vitest-dev/vitest/issues/8757)). All 20 `AuthForm.test.tsx` tests failed on a local Node 26 machine while CI (Node 20) stayed green.

`setupTests.ts` now installs an in-memory Storage for `localStorage`/`sessionStorage` only when the environment didn't provide a working one — a no-op on Node 20, a fix on Node 25+.

## Test plan

- Full vitest suite: 183/183 pass locally on Node 26 (was 163 passed / 20 failed)
- `npm run test:ci` (the exact CI command, with coverage) passes locally; thresholds met
- tsc, eslint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)